### PR TITLE
widget demo: enable Windows system DPI awareness

### DIFF
--- a/demos/widget
+++ b/demos/widget
@@ -19,6 +19,17 @@ use strict;
 
 $XFT = $Tk::Config::xlib =~ /-lXft\b/;
 
+
+# Enable system DPI awareness for sharper UI on Windows
+# https://www.perlmonks.org/?node_id=11101747
+if ($^O eq 'MSWin32') {
+    require Win32::API;
+    # See https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-setprocessdpiaware
+    my $SetProcessDPIAware = Win32::API::More->new('User32', 'BOOL SetProcessDPIAware()');
+    $SetProcessDPIAware->Call() or warn 'Failed to set process DPI awareness';
+}
+
+
 $MW = Tk::MainWindow->new;
 $MW->configure(-menu => my $menubar = $MW->Menu);
 


### PR DESCRIPTION
From writeup on Perlmonks: https://www.perlmonks.org/?node_id=11101747 (see also https://github.com/chrstphrchvz/perl-tcl-ptk/issues/6#issuecomment-637166868)

Before:
![image](https://user-images.githubusercontent.com/7941193/87824182-69635f80-c83a-11ea-93d8-08d368395fd5.png)

After:
![image](https://user-images.githubusercontent.com/7941193/87824244-8435d400-c83a-11ea-94f3-811daefb6463.png)

Maybe some further refinements e.g. to font size might help even more.